### PR TITLE
Correct tokenURL

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -10,7 +10,7 @@ const profile = require("./profile");
 function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || "https://auth.getmondo.co.uk";
-  options.tokenURL = options.tokenURL || "https://api.getmondo.co.uk/oauth/token";
+  options.tokenURL = options.tokenURL || "https://api.getmondo.co.uk/oauth2/token";
   options.customHeaders = options.customHeaders || {};
 
   if (!options.customHeaders["User-Agent"]) {


### PR DESCRIPTION
Not sure if this URL has changed but https://api.getmondo.co.uk/oauth/token throws a server error.

Exchanging for the token url from https://getmondo.co.uk/docs/#acquire-an-access-token fixes this